### PR TITLE
Issue #59 alarming

### DIFF
--- a/evac/worker.py
+++ b/evac/worker.py
@@ -28,6 +28,7 @@ from collections import OrderedDict
 from subprocess import Popen, run, TimeoutExpired
 import zipfile
 import multiprocessing
+import pandas as pd
 
 SIMULATION_TYPE = 1
 if 'AAMKS_SKIP_CFAST' in os.environ:
@@ -69,6 +70,7 @@ class Worker:
         self.position_fed_tables_information = []
         ssl._create_default_https_context = ssl._create_unverified_context
         self.rows_to_insert = []
+        self.detection_time = None
 
 
     def get_logger(self, logger_name):
@@ -206,6 +208,20 @@ class Worker:
         self.obstacles = json.loads(self.s.query('SELECT * FROM obstacles')[0]['json'], object_pairs_hook=OrderedDict)
         self.wlogger.info('SQLite load successfully')
 
+    def _get_detection_time(self):
+        heat = any(self.project_conf['smoke_detectors'].values())
+        smoke = any(self.project_conf['heat_detectors'].values())
+        sprink = any(self.project_conf['sprinklers'].values())
+        if any([heat, smoke, sprink]):
+            df = pd.read_csv('cfast_devices.csv')[3:].astype(float)
+            if (df.filter(like='SENSACT').iloc[-1] == 1).any():
+                det = df['Time'].loc[(df.filter(like='SENSACT') == 1).idxmax().max()]
+            del df
+        try:
+            return det
+        except NameError:
+            return round(normal(loc=self.project_conf['detection']['mean'], scale=self.project_conf['detection']['sd']), 2)
+
     def _create_evacuees(self, floor):
 
         evacuees = []
@@ -215,7 +231,7 @@ class Worker:
 
         for i in floor['EVACUEES'].keys():
             evacuees.append(Evacuee(origin=tuple(floor['EVACUEES'][i]['ORIGIN']), v_speed=floor['EVACUEES'][i]['V_SPEED'],
-                                    h_speed=floor['EVACUEES'][i]['H_SPEED'], pre_evacuation=floor['EVACUEES'][i]['PRE_EVACUATION'],
+                                    h_speed=floor['EVACUEES'][i]['H_SPEED'], pre_evacuation=self.detection_time+floor['EVACUEES'][i]['PRE_EVACUATION'],
                                     alpha_v=floor['EVACUEES'][i]['ALPHA_V'], beta_v=floor['EVACUEES'][i]['BETA_V'],
                                     node_radius=self.config['NODE_RADIUS']))
             self.wlogger.debug('{} evacuee added'.format(i))
@@ -236,6 +252,7 @@ class Worker:
         return stair_cases
 
     def prepare_simulations(self):
+        self.detection_time = self._get_detection() #rough - with CFAST SPREADSHEET resolution
 
         for floor in sorted(self.obstacles['obstacles'].keys()):
             eenv = None
@@ -499,6 +516,8 @@ class Worker:
             report['floor'] = num_floor
         report['psql']['i_risk'] = RI(report['psql']['fed'], calculate=True).export()
 
+        report['psql']['detection'] = self.detection_time
+
         self.meta_file = "meta_{}.json".format(self.sim_id)
         j.write(report, self.meta_file)
         self.wlogger.info('Metadata prepared successfully')
@@ -543,6 +562,7 @@ class Worker:
         self.send_report()
 
     def local_worker(self):
+        print(self.working_dir)
         os.chdir(self.working_dir)
         self.get_config()
         self.create_geom_database()
@@ -557,9 +577,9 @@ class Worker:
 
 w = Worker()
 #print(os.environ['AAMKS_WORKER'])
-os.environ['AAMKS_WORKER'] = 'gearman'
-os.environ['AAMKS_PATH'] = '/usr/local/aamks'
-os.environ['AAMKS_SERVER'] = '192.168.0.185'
+#os.environ['AAMKS_WORKER'] = 'gearman'
+#os.environ['AAMKS_PATH'] = '/usr/local/aamks'
+#os.environ['AAMKS_SERVER'] = '192.168.0.185'
 if SIMULATION_TYPE == 'NO_CFAST':
     print('Working in NO_CFAST mode')
     w.test()

--- a/installer/sql.sql
+++ b/installer/sql.sql
@@ -62,6 +62,7 @@ CREATE TABLE simulations ( ---{{{
     vnt text,
     vvent text,
     sprinklers text,
+    detection integer
     wcbe text,
     dcbe_time integer,
     dcbe_compa text,

--- a/manager/results_collector.py
+++ b/manager/results_collector.py
@@ -101,7 +101,7 @@ class ResultsCollector():
         [dfed.apply(update_fed_growth, axis=1, floor=f) for f, dfed in enumerate(dfeds)]
 
         # simulations table
-        p.query(f"""UPDATE simulations SET fed = '{fed}', fed_symbolic = '{fed_symbolic}', wcbe='{rset}', 
+        p.query(f"""UPDATE simulations SET fed = '{fed}', fed_symbolic = '{fed_symbolic}', wcbe='{rset}', detection = '{self.meta['psql']['detection']}', 
                 run_time = {self.meta['psql']['runtime']}, dcbe_time = {self.meta['psql']['cross_building_results']['dcbe']},
                 min_vis_compa = {self.meta['psql']['cross_building_results']['min_vis_compa']},
                 max_temp = {self.meta['psql']['cross_building_results']['max_temp_compa']}, host = '{self.meta['worker']}',

--- a/montecarlo/cfast_mcarlo.py
+++ b/montecarlo/cfast_mcarlo.py
@@ -613,7 +613,7 @@ class DrawAndLog:
         hrr = HRR(self.conf)
         t_up_to_hrr_peak = int((hrr_peak/self.alpha)**0.5)
         hrr.add_tsquared([0, t_up_to_hrr_peak], self.alpha)
-        hrr.add_const([t_up_to_hrr_peak, self.conf['simulation_time']], hrr_peak)
+        hrr.add_const([t_up_to_hrr_peak, hrr.sim_time], hrr_peak)
         hrr.fuel_control(load_density * fire_area)
         hrr.firefighting()
 
@@ -762,11 +762,19 @@ class HRR:
 
     def all(self): return {'t': self.domains, 'f': self.functions}    #t = [t0, t1] are time domains for functions f = [c, b, a] for f(t) = at^2 + bt +c
 
-    def _break_domains(self, t):
-        if t[0] > t[1]:
+    def _break_domains(self, t, v=False):
+        if t[0] > self.sim_time:
+            if not v:
+                return False
+            raise ValueError(f'Lower limit {t[0]} must not be greater than simulation time {self.sim_time}')
+        elif t[0] > t[1]:
+            if not v:
+                return False
             print(self.domains)
             raise ValueError(f'Lower limit must be lower than upper limit {t}')
         elif t[0] == t[1]:
+            if not v:
+                return False
             print(self.domains)
             raise ValueError(f'Lower and upper limits must not be equal {t}')
 
@@ -780,7 +788,22 @@ class HRR:
                     self.domains[i+add_i][1] = tb
                     add_i += 1
 
-    def _update_funcs(self, t, f):
+    def _update_funcs(self, t, f, v=False):
+        if t[0] > self.sim_time:
+            if not v:
+                return False
+            raise ValueError(f'Lower limit {t[0]} must not be greater than simulation time {self.sim_time}')
+        elif t[0] > t[1]:
+            if not v:
+                return False
+            print(self.domains)
+            raise ValueError(f'Lower limit must be lower than upper limit {t}')
+        elif t[0] == t[1]:
+            if not v:
+                return False
+            print(self.domains)
+            raise ValueError(f'Lower and upper limits must not be equal {t}')
+
         for i, domain in enumerate(self.domains):
             # update function if existing domain is in updated function domain
             if t[0] <= domain[0] and domain[1] <= t[1]:

--- a/montecarlo/cfast_mcarlo.py
+++ b/montecarlo/cfast_mcarlo.py
@@ -371,10 +371,10 @@ class CfastMcarlo():
 # }}}
     def _section_sprinklers(self):# {{{
         txt=['!! SECTION SPRINKLERS']
-        for v in self.s.query("SELECT * from aamks_geom WHERE type_pri='COMPA' AND fire_model_ignore!=1 AND sprinklers=1"):
+        for i, v in enumerate(self.s.query("SELECT * from aamks_geom WHERE type_pri='COMPA' AND fire_model_ignore!=1 AND sprinklers=1")):
             try:
-                temp, dens = self.samples['sprinklers']    # ACTIVATION_TEMPERATURE,
-            except ValueError:
+                temp, dens = self.samples['sprinklers'][i]    # ACTIVATION_TEMPERATURE,
+            except TypeError:
                 collect =[]
             else: 
                 collect=[]

--- a/montecarlo/evac_mcarlo.py
+++ b/montecarlo/evac_mcarlo.py
@@ -89,17 +89,22 @@ class EvacMcarlo():
         self.s.query("UPDATE obstacles SET json=?", (json.dumps(obstacles),)) 
 
 # }}}
+    def _get_alarming_time(self):
+        return round(normal(loc=self.conf['alarming']['mean'], scale=self.conf['alarming']['sd']), 2)
+
     def _make_pre_evacuation(self,room,type_sec):# {{{
         ''' 
         An evacuee pre_evacuates from either ordinary room or from the room of
         fire origin; type_sec is for future development.
+        Detection from CFAST or config when no detectors in worker.py
+        Alarming form config
         '''
 
         if room != self._evac_conf['FIRE_ORIGIN']:
             pe=self.conf['pre_evac']
         else:
             pe=self.conf['pre_evac_fire_origin']
-        return round(lognorm(s=1, loc=pe['mean'], scale=pe['sd']).rvs(), 2)
+        return self._get_alarming_time() + round(lognorm(s=1, loc=pe['mean'], scale=pe['sd']).rvs(), 2)
 # }}}
     def _get_density(self,name,type_sec,floor):# {{{
         ''' 


### PR DESCRIPTION
This pull-request consists ofthe following changes.
1. Alarming time from the form.
2. Detection time from CFAST results. 1800 s if not available.
Consider adjusting when `fire.partition_query.get_final_vars()` is called in `evac.worker`. Detection time is already returned by this function, but it is called at the end of evacuation simulation.
3. Fixes in `montecarlo.cfast_mcarlo`: sprinklers are working properly now and no errors are raised when you try to add a function after the simulation end, that operation is simply skipped.

Requires update of postgres table (`installer.sql.sql`).

Resolves #59. 