### PR TITLE
Maximum fire area fixed

### DIFF
--- a/montecarlo/cfast_mcarlo.py
+++ b/montecarlo/cfast_mcarlo.py
@@ -633,15 +633,15 @@ class DrawAndLog:
         Fire area is draw from pareto distrubution regarding the BS PD-7974-7. 
         There is lack of vent condition - underventilated fires
         '''
-        orig_area = math.prod([dim * 2 for dim in self.sections['FIRE']['LOCATION']]) #[m2]
+        orig_area = self.s.query(f"SELECT width*depth/10000 AS area FROM aamks_geom WHERE name='{self._fire_room_name}'")[0]['area']    # [m2]
         if self.conf['r_is']!='simple':
             fire_area = orig_area
         else:
             p = pareto(b=self.conf['fire_area']['b'], scale=self.conf['fire_area']['scale'])
-            fire_area = round(p.rvs(size=1)[0], 2)
+            fire_area = round(p.rvs(size=1)[0], 2)  #[m2]
             if fire_area > orig_area:
                 fire_area = orig_area
-        return fire_area
+        return fire_area    #[m2]
 
     def _flashover_q(self, model='max'):
         fire_room = self.s.query(f"SELECT width, depth, height FROM aamks_geom WHERE name='{self._fire_room_name}'")[0]

--- a/montecarlo/cfast_mcarlo.py
+++ b/montecarlo/cfast_mcarlo.py
@@ -569,7 +569,7 @@ class DrawAndLog:
                 (fire['floor'], fire['x0'], fire['y0'], fire['x1'], fire['y1']))[0]
 
         loc['global'] =  [fire['center_x'], fire['center_y'], fire['z0']]
-        loc['local'] = [fire['center_x'] - fire['x0'], fire['center_y'] - fire['y0']]  # seems irrelevant ? - to be investigated [WK]
+        loc['local'] = [fire['center_x'] - room['x0'], fire['center_y'] - room['y0']]
         loc['local'] = [round(i/100, 2) for i in loc['local']]
         loc['floor'] = room['floor']
         loc['fire_id'] = f"f{room['global_type_id']}"


### PR DESCRIPTION
Maximum area for fire (area of room of fire origin) is calculated directly as room width multiplied by the depth from aamks.sqlite.

It will lower peak HRR in scenarios where fire occurs in well-ventilated compartments of low fire load density. Could also improve CFAST pressure errors in those cases.