### PR TITLE
CFAST sim time +1 s

### DIFF
--- a/montecarlo/cfast_mcarlo.py
+++ b/montecarlo/cfast_mcarlo.py
@@ -139,7 +139,7 @@ class CfastMcarlo():
     def _section_preamble(self):# {{{
         txt=(
         f"&HEAD VERSION = 7724, TITLE = 'P_ID_{self.conf['project_id']}_S_ID_{self.conf['scenario_id']}' /",
-        f"&TIME SIMULATION = {self.conf['simulation_time']}, PRINT = {self.config['SMOKE_QUERY_RESOLUTION']}, SMOKEVIEW = {self.config['SMOKE_QUERY_RESOLUTION']}, SPREADSHEET = {self.config['SMOKE_QUERY_RESOLUTION']} /",
+        f"&TIME SIMULATION = {self.conf['simulation_time']+1}, PRINT = {self.config['SMOKE_QUERY_RESOLUTION']}, SMOKEVIEW = {self.config['SMOKE_QUERY_RESOLUTION']}, SPREADSHEET = {self.config['SMOKE_QUERY_RESOLUTION']} /",
         self._cfast_record('INIT'),
         f"&MISC LOWER_OXYGEN_LIMIT = 0.15, MAX_TIME_STEP = 0.1/",
         '',


### PR DESCRIPTION
Time for CFAST extended to avoid smoke query error (status 33) when evac runs through the whole simulation time. Closes #286.