### PR TITLE
Avoid negative cell numbering

### DIFF
--- a/evac/rvo2_dto.py
+++ b/evac/rvo2_dto.py
@@ -509,8 +509,8 @@ class FEDDerivative:
         def minmax(pts):
             ret = []
             xys = list(zip(*pts))
-            ret.append([min(xys[i]) for i in range(2)])
-            ret.append([max(xys[i]) for i in range(2)])
+            ret.append([min(xys[i])-100 for i in range(2)])
+            ret.append([max(xys[i])+100 for i in range(2)])
             return ret
 
         for i in q:


### PR DESCRIPTION
Extend heatmap canvas with 100 cm - value assumed to be sufficient according to navmesh limits. Resolves #295. 