### PR TITLE
safe_remove added

### DIFF
--- a/evac/worker.py
+++ b/evac/worker.py
@@ -851,27 +851,26 @@ class Worker:
         return collected_fed
 
     def cleanup(self):
+        def safe_remove(path):
+            try:
+                os.remove(path)
+            except:
+                pass
         if not self.is_anim:
-            os.remove("finals.sqlite")
-            os.remove("cfast_devices.csv")
-            os.remove("cfast_vents.csv")
-            os.remove("cfast_walls.csv")
-            os.remove("cfast_masses.csv")
-            os.remove("cfast_zone.csv")
-            os.remove("cfast.log")
-            os.remove("cfast.smv")
-            os.remove("cfast.out")
-            os.remove("cfast.plt")
-            os.remove("cfast.status")
-            os.remove("cfast_evac_socket_port.txt")
-            # os.remove("doors_opening_level_frame.txt") #fortran issue
-            # os.remove("times.txt")
-            shutil.rmtree("door_opening_changes")
+            safe_remove("finals.sqlite")
+            safe_remove(f"aamks_{self.sim_id}.sqlite")
+            safe_remove("cfast_devices.csv")
+            safe_remove("cfast_vents.csv")
+            safe_remove("cfast_walls.csv")
+            safe_remove("cfast_masses.csv")
+            safe_remove("cfast_zone.csv")
+            safe_remove("cfast.log")
+            safe_remove("cfast.smv")
+            safe_remove("cfast.out")
+            safe_remove("cfast.plt")
+            safe_remove("cfast.status")
             for floor in self.floors:
-                try:
-                    os.remove(f'pynavmesh{floor.floor}.nav')
-                except FileNotFoundError:
-                    continue
+                safe_remove(f'pynavmesh{floor.floor}.nav')
 
     def main(self):
         self.get_config()


### PR DESCRIPTION
Wrap each `os.remove()` in broad try except clause. Broad, because we only want to avoid redis worker crashes.

Again resolves #284 